### PR TITLE
Db options

### DIFF
--- a/duty.js
+++ b/duty.js
@@ -370,11 +370,15 @@ function _dbError( err ) {
         return err;
     }
 
-    dbOptions || ( dbOptions = {} );
+    if ( dbOptions && dbOptions.deepError ) {
+        var serialized = serializeError( err );
 
-    // we dont want to save the stack
-    delete err.stack;
-    return dbOptions.deepError ? serializeError( err ) : err.toString();
+        // we dont want to store the stack
+        delete serialized.stack;
+        return serialized;
+    }
+
+    return err.toString();
 }
 
 // clear expired jobs once a minute

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "dbstream-memory": "^0.1.0",
-    "extend": "^2.0.1"
+    "extend": "^2.0.1",
+    "serialize-error": "^2.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -176,6 +176,7 @@ describe( "Duty", function () {
                 assert( job.error )
                 assert.equal( job.error.message, "Something went wrong" )
                 assert.equal( job.error.type, "test" );
+                assert( !job.error.stack )
                 done( err )
             })
         }

--- a/test.js
+++ b/test.js
@@ -158,6 +158,29 @@ describe( "Duty", function () {
         }
     });
 
+    it( "stores job error as object", function ( done ) {
+        var conn = duty.db();
+        var options = { deepError: true };
+        var error = new Error( "Something went wrong" );
+        error.type = "test"
+        
+        duty.db( conn, options )
+        var job = duty( "test", {} );
+        duty.register( "test", function ( data, cb ) {
+            cb( error, { ok: 1 } );
+            setTimeout( complete, 20 );
+        })
+
+        function complete() {
+            duty.get( job.id, function ( err, job ) {
+                assert( job.error )
+                assert.equal( job.error.message, "Something went wrong" )
+                assert.equal( job.error.type, "test" );
+                done( err )
+            })
+        }
+    })
+
     it( "supports job retries", function ( done ) {
         var job = duty( "test", {} );
         var errorNext = true;
@@ -328,7 +351,7 @@ describe( "Duty", function () {
         });
 
         function complete () {
-            assert.equal( err, "Canceled" );
+            assert.equal( err, "Error: Canceled" );
             assert( count >= 1 && count <= 3, "1 <= " + count + " <= 3" );
             done();
         }
@@ -536,6 +559,9 @@ describe( "Duty", function () {
 // duty.db( conn );
 function reset( done ) {
     duty.unregister();
+    var conn = duty.db();
+    // restore to the defautl db options
+    duty.db( conn );
     var jobs = [];
     var Cursor = duty.db().Cursor;
     new Cursor()


### PR DESCRIPTION
@avinoamr Currently the duty save only the value of `error.toString()` as the `job.error` to the db. This PR add the options to call `duty.db( conn, options )` with a map of options. 
that currently support only `options.deepError` a Boolean parameter to force duty to save the fully representation of the error Object using [serialize-error](https://www.npmjs.com/package/serialize-error). instead of just the value of `error.toString()`
